### PR TITLE
Fix formatting of code

### DIFF
--- a/_posts/2015-11-15-sinatra-app.markdown
+++ b/_posts/2015-11-15-sinatra-app.markdown
@@ -263,13 +263,13 @@ set :erb, :layout => :'layouts/application'
 
 Lets examine the first four lines in a bit more detail:
 
-**require 'bundler'** enables our application to automatically discover the `Gemfile`.
+`require 'bundler'` enables our application to automatically discover the `Gemfile`.
 
-**Bundler.require** loads into the project all the gems that are specified in the `Gemfile`.
+`Bundler.require` loads into the project all the gems that are specified in the `Gemfile`.
 
-**$: << File.expand_path('../', __FILE__)** adds the entire project to $LOAD_PATH. This allows Sinatra to find all the files you’ve added to the project.
+`$: << File.expand_path('../', __FILE__)` adds the entire project to $LOAD_PATH. This allows Sinatra to find all the files you’ve added to the project.
 
-**Dir['./app/\*\*/*.rb'].sort.each { |file| require file }** This line explicitly requires each file found in our model, view and controller folders.
+`Dir['./app/\*\*/*.rb'].sort.each { |file| require file }` This line explicitly requires each file found in our model, view and controller folders.
 
 Even though we haven't set them up yet, we know the project is going to need these files.
 The last three lines of `application.rb` sets the root of the project and tells the application where the erb (embedded Ruby) files and CSS files are located.


### PR DESCRIPTION
The markdown `**bold**` syntax played funny with some code examples.

Changed from this:

<img width="861" alt="screen shot 2016-02-07 at 1 54 08 pm" src="https://cloud.githubusercontent.com/assets/3443017/12870828/3476f86e-cda2-11e5-9161-9330faf3ccba.png">

To this:

<img width="847" alt="screen shot 2016-02-07 at 1 53 29 pm" src="https://cloud.githubusercontent.com/assets/3443017/12870825/279a4ede-cda2-11e5-86e9-c277cec1170a.png">
